### PR TITLE
fix Threading

### DIFF
--- a/source/Infiniminer/Infiniminer.Client.Shared/InfiniminerGame.cs
+++ b/source/Infiniminer/Infiniminer.Client.Shared/InfiniminerGame.cs
@@ -415,7 +415,7 @@ namespace Infiniminer
             }
 
             // Make sure our network thread actually gets to run.
-            Thread.Sleep(1);
+            Thread.Sleep(0);
         }
 
         private void CheckForStandingInLava()

--- a/source/Infiniminer/Infiniminer.Server/InfiniminerServer.cs
+++ b/source/Infiniminer/Infiniminer.Server/InfiniminerServer.cs
@@ -817,7 +817,7 @@ namespace Infiniminer
                 }
 
                 // Pass control over to waiting threads.
-                Thread.Sleep(1);
+                Thread.Sleep(0);
             }
 
             netServer.Shutdown("The server was terminated.");


### PR DESCRIPTION
Sleep zero is the correct method for Passing control over to waiting
threads.
This improve the performance on WindowsDX.

https://learn.microsoft.com/en-us/dotnet/api/system.threading.thread.sleep?view=net-7.0#system-threading-thread-sleep(system-int32)

"If the value of the timeout argument is Zero, the thread relinquishes
the remainder of its time slice to any thread of equal priority that is
ready to run. If there are no other threads of equal priority that are
ready to run, execution of the current thread is not suspended."