### PR TITLE
fix pointSamplerState

### DIFF
--- a/source/Infiniminer/Infiniminer.Client.Shared/Engines/InterfaceEngine.cs
+++ b/source/Infiniminer/Infiniminer.Client.Shared/Engines/InterfaceEngine.cs
@@ -58,7 +58,7 @@ namespace Infiniminer
             uiEffect.VertexColorEnabled = true;
 
             // Create states.
-            pointSamplerState = new SamplerState() { Filter = TextureFilter.Point };
+            pointSamplerState = SamplerState.PointClamp;
 
             // Load textures.
             texCrosshairs = gameInstance.Content.Load<Texture2D>("ui/tex_ui_crosshair");


### PR DESCRIPTION
In RenderDetonator(), RenderProspectron() and RenderConstructionGun(),
the sample state need to be Clamp for non-power-of-2 textures in Reach
GraphicsProfile.

pointSamplerState replaces with the predefined SamplerState.PointClamp.