### PR TITLE
preserve Infiniminer.States.* types for nativeAOT trimming

### DIFF
--- a/source/Infiniminer/Infiniminer.Client.Shared/ILLink.Descriptors.Kni.xml
+++ b/source/Infiniminer/Infiniminer.Client.Shared/ILLink.Descriptors.Kni.xml
@@ -1,0 +1,11 @@
+<linker>
+  <assembly fullname="Infiniminer.Client.Shared.Kni">
+    <type fullname="Infiniminer.States.ClassSelectionState" preserve="all"/>
+    <type fullname="Infiniminer.States.DebugState" preserve="all"/>
+    <type fullname="Infiniminer.States.LoadingState" preserve="all"/>
+    <type fullname="Infiniminer.States.MainGameState" preserve="all"/>
+    <type fullname="Infiniminer.States.ServerBrowserState" preserve="all"/>
+    <type fullname="Infiniminer.States.TeamSelectionState" preserve="all"/>
+    <type fullname="Infiniminer.States.TitleState" preserve="all"/>
+  </assembly>
+</linker>

--- a/source/Infiniminer/Infiniminer.Client.Shared/Infiniminer.Client.Shared.Kni.csproj
+++ b/source/Infiniminer/Infiniminer.Client.Shared/Infiniminer.Client.Shared.Kni.csproj
@@ -15,4 +15,11 @@
   <ItemGroup>
     <ProjectReference Include="..\Infiniminer.Shared\Infiniminer.Shared.Kni.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="ILLink.Descriptors.Kni.xml">
+      <LogicalName>ILLink.Descriptors.xml</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This fixes publishing the SDL2/openGL with native AOT.

The state manager is using strings to switch between states like '_nextState = "Infiniminer.States.TeamSelectionState";_'
I've tried tried to convert those into types, like '_nextState = typeofInfiniminer.States.TeamSelectionState);_' but that still doesn't prevent trimming the parameterless .ctor and possibly most of states methods.

The win-x64 executable becomes ~12MB from ~7MB with this change, but now it works without crashing at startup. 


